### PR TITLE
Fix bson version and add python2/3 compatibility

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Build-Depends: debhelper (>= 9),
                python3-requests,
                python3-requests-oauthlib,
                python3-setuptools,
+               python3-six,
                python3-bson
 Standards-Version: 3.9.5
 Homepage: https://github.com/Ubuntu-Solutions-Engineering/maasclient
@@ -28,6 +29,7 @@ Depends: python3-all,
          python3-requests,
          python3-requests-oauthlib,
          python3-setuptools,
+         python3-six,
          python3-bson,
          ${misc:Depends},
          ${python3:Depends}

--- a/maasclient/__init__.py
+++ b/maasclient/__init__.py
@@ -20,7 +20,7 @@ import bson
 from requests_oauthlib import OAuth1
 import requests
 import json
-from urllib.parse import urlsplit
+from six.moves.urllib.parse import urlsplit
 
 
 class MaasClient:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 requests_oauthlib
-bson
+bson==0.4.1
+six


### PR DESCRIPTION
I guess the focus of attention has shifted to the new API version / package, but this PR allows using maasclient with python2 for MAAS < 2.0.

I also fixed the bson version at 0.4.1, since newer bson installation dies with:

```
Collecting bson (from maasclient==0.4.1)
  Downloading bson-1.1.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/r2/6_50f60s0215s8fq_r7wdzsh0000gn/T/pip-build-fJUyuG/bson/setup.py", line 24, in <module>
        import bson
      File "bson/__init__.py", line 66, in <module>
        from . import codec
      File "bson/codec.py", line 28, in <module>
        from .objects import *
      File "bson/objects.py", line 36
        class BSONObject(object, metaclass=ABCMeta):
                                          ^
    SyntaxError: invalid syntax
```
